### PR TITLE
Dynamically disable mesh_renderer dependency when running on Windows

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,14 +1,14 @@
 import tensorflow as tf 
 import numpy as np
-import cv2
 from PIL import Image
-import os
-import glob
+import os, glob, cv2, platform
 from scipy.io import loadmat,savemat
 
 from preprocess_img import Preprocess
 from load_data import *
 from face_decoder import Face3D
+
+is_windows = platform.system() == "Windows"
 
 def load_graph(graph_filename):
 	with tf.gfile.GFile(graph_filename,'rb') as f:
@@ -77,11 +77,14 @@ def demo():
 				face_texture_ = np.squeeze(face_texture_, (0))
 				face_color_ = np.squeeze(face_color_, (0))
 				landmarks_2d_ = np.squeeze(landmarks_2d_, (0))
-				recon_img_ = np.squeeze(recon_img_, (0))
+				recon_img_ = None
+				if not is_windows:
+					recon_img_ = np.squeeze(recon_img_, (0))
 
 				# save output files
-				savemat(os.path.join(save_path,file.split(os.path.sep)[-1].replace('.png','.mat').replace('jpg','mat')),{'cropped_img':input_img[:,:,::-1],'recon_img':recon_img_,'coeff':coeff_,\
-					'face_shape':face_shape_,'face_texture':face_texture_,'face_color':face_color_,'lm_68p':landmarks_2d_,'lm_5p':lm_new})
+				if recon_img_:
+					savemat(os.path.join(save_path,file.split(os.path.sep)[-1].replace('.png','.mat').replace('jpg','mat')),{'cropped_img':input_img[:,:,::-1],'recon_img':recon_img_,'coeff':coeff_,\
+						'face_shape':face_shape_,'face_texture':face_texture_,'face_color':face_color_,'lm_68p':landmarks_2d_,'lm_5p':lm_new})
 				save_obj(os.path.join(save_path,file.split(os.path.sep)[-1].replace('.png','_mesh.obj').replace('jpg','_mesh.obj')),face_shape_,tri_,np.clip(face_color_,0,255)/255) # 3D reconstruction face (in canonical view)
 
 if __name__ == '__main__':

--- a/demo.py
+++ b/demo.py
@@ -1,7 +1,10 @@
 import tensorflow as tf 
 import numpy as np
 from PIL import Image
-import os, glob, cv2, platform
+import os
+import glob
+import cv2
+import platform
 from scipy.io import loadmat,savemat
 
 from preprocess_img import Preprocess
@@ -77,12 +80,11 @@ def demo():
 				face_texture_ = np.squeeze(face_texture_, (0))
 				face_color_ = np.squeeze(face_color_, (0))
 				landmarks_2d_ = np.squeeze(landmarks_2d_, (0))
-				recon_img_ = None
 				if not is_windows:
 					recon_img_ = np.squeeze(recon_img_, (0))
 
 				# save output files
-				if recon_img_:
+				if not is_windows:
 					savemat(os.path.join(save_path,file.split(os.path.sep)[-1].replace('.png','.mat').replace('jpg','mat')),{'cropped_img':input_img[:,:,::-1],'recon_img':recon_img_,'coeff':coeff_,\
 						'face_shape':face_shape_,'face_texture':face_texture_,'face_color':face_color_,'lm_68p':landmarks_2d_,'lm_5p':lm_new})
 				save_obj(os.path.join(save_path,file.split(os.path.sep)[-1].replace('.png','_mesh.obj').replace('jpg','_mesh.obj')),face_shape_,tri_,np.clip(face_color_,0,255)/255) # 3D reconstruction face (in canonical view)

--- a/face_decoder.py
+++ b/face_decoder.py
@@ -2,7 +2,7 @@ import tensorflow as tf
 import math as m
 import numpy as np
 from scipy.io import loadmat
-import platform, PIL
+import platform
 
 is_windows = platform.system() == "Windows"
 
@@ -301,7 +301,6 @@ class Face3D():
 					far_clip = far_clip)
 			return img
 		else:
-			#return PIL.Image.new('RGB', (224, 224))
 			return np.zeros([224, 224], dtype=np.int32)
 
 


### PR DESCRIPTION
As described in the readme, until now you had to manually comment out the rendering code to run the demo on Windows. Instead of just commenting out the code that uses mesh_renderer, I used the Python `platform` module to check if the script is running on Windows and dynamically disable the dependency.
This way the demo.py still renders the images in a full environment on Linux, but also runs on Windows, creating the mesh files.